### PR TITLE
Fix user creation: map `maternalLastName`, validate type, and respect `classify`

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -43,12 +43,20 @@ router.get('/', authRequired, requireAdmin, async (req, res) => {
  */
 router.post('/', authRequired, requireAdmin, async (req, res) => {
   try {
-    const { name, lastName, email, phone, role, classify } = req.body;
+    const { name, lastName, maternalLastName, email, phone, role, classify } = req.body;
 
     if (!name || !lastName || !email) {
       return res.status(400).json({
         message: 'Faltan datos obligatorios (name, lastName, email)',
       });
+    }
+
+    if (typeof maternalLastName !== 'undefined' && maternalLastName !== null) {
+      if (typeof maternalLastName !== 'string') {
+        return res
+          .status(400)
+          .json({ message: 'maternalLastName debe ser string o null' });
+      }
     }
 
     // Evitar duplicado por email
@@ -65,11 +73,12 @@ router.post('/', authRequired, requireAdmin, async (req, res) => {
       data: {
         name,
         lastName,
-        maternalLastName: true,
+        maternalLastName:
+          typeof maternalLastName === 'undefined' ? null : (maternalLastName || null),
         email,
         phone: phone || null,
         role: role || 'CLIENT',
-        classify: 'GOOD', // Ajuste por defecto
+        classify: typeof classify === 'undefined' ? 'GOOD' : classify,
         active: true,
         password: passwordHash, // ✅ requerido por Prisma
       },


### PR DESCRIPTION
### Motivation
- Prevent saving a boolean `true` into the `maternalLastName` field when creating a user by mapping the payload value correctly to the Prisma model.
- Avoid runtime errors by validating the incoming `maternalLastName` type before writing to the database.
- Preserve an explicitly provided `classify` value instead of always forcing the default `GOOD`.

### Description
- Destructure `maternalLastName` from `req.body` and use it in the `prisma.user.create` `data` payload instead of a hardcoded `true` value.
- Validate that `maternalLastName` is either a `string` or `null` and return `400` on invalid types.
- Map `maternalLastName` to `null` when omitted and set `classify` to `GOOD` only when `classify` is `undefined` (respect provided values otherwise).
- Changes implemented in `backend/src/routes/users.js` around the `POST /api/users` handler and the `prisma.user.create` call.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e9beef10832fb6873402a39b8ed4)