### PR TITLE
Usar `handleChange` para el input Nombre en AdminNewUser

### DIFF
--- a/frontend/src/pages/AdminNewUser.jsx
+++ b/frontend/src/pages/AdminNewUser.jsx
@@ -202,7 +202,7 @@ export default function AdminNewUser() {
                   <input
                     type="text"
                     value={form.name}
-                    onChange={(e) => setName(e.target.value)}
+                    onChange={(e) => handleChange('name', e.target.value)}
                     placeholder="Nombre"
                     required
                   />


### PR DESCRIPTION
### Motivation
- Unificar la estrategia de actualización del formulario para evitar mezclas de manejadores y posibles errores.
- Corregir un uso de `setName` que no existe en este componente y podría provocar fallos al editar el nombre.
- Mantener coherencia con el resto de inputs que ya utilizan el manejador común `handleChange`.
- Mejorar la mantenibilidad del formulario en `frontend/src/pages/AdminNewUser.jsx`.

### Description
- Reemplazado `onChange={(e) => setName(e.target.value)}` por `onChange={(e) => handleChange('name', e.target.value)}` en `frontend/src/pages/AdminNewUser.jsx`.
- No se cambiaron los demás campos porque ya usan `handleChange` de forma consistente.
- No se añadieron dependencias ni se modificó la lógica de envío del formulario (`handleSubmit`).
- Archivo afectado: `frontend/src/pages/AdminNewUser.jsx`.

### Testing
- No se ejecutaron pruebas automáticas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960ece21cf4832f8e603ad28457e5e5)