### PR TITLE
Unifica estética de Login y Dashboards con la identidad Coworking Sinergia

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,7 +62,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1537,7 +1536,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1591,7 +1589,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1724,7 +1721,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2145,7 +2141,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3752,7 +3747,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3794,6 +3788,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -3840,7 +3835,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3850,7 +3844,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4362,7 +4355,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4484,7 +4476,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -68,146 +68,59 @@ export default function Header({ user, onToggleSidebar }) {
   }
 
   return (
-    <header
-      style={{
-        width: '100%',
-        backgroundColor: '#33576f',
-        padding: '0.75rem 1.5rem',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        borderBottom: '1px solid #33576f',
-        boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
-        zIndex: 30,
-        position: 'relative',
-      }}
-    >
-      {/* Logo + nombre coworking + botón sidenav */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+    <header className="app-header">
+      <div className="app-header__brand">
         {onToggleSidebar && (
           <button
             type="button"
             onClick={onToggleSidebar}
             aria-label="Alternar menú lateral"
-            style={{
-              border: 'none',
-              background: '#33576f',
-              width: 36,
-              height: 36,
-              borderRadius: '999px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              cursor: 'pointer',
-              boxShadow: '0 0 0 1px #33576f',
-            }}
+            className="app-header__menu-btn"
           >
-            <span style={{ fontSize: '1.2rem', lineHeight: 1, color: 'white', fontWeight: 'bold' }}>
-              ☰
-            </span>
+            <span className="app-header__menu-icon">☰</span>
           </button>
         )}
 
-        <img src={logo} alt="Logo" style={{ width: 40, height: 40, borderRadius: '0.5rem' }} />
-        <h2 style={{ margin: 0, fontSize: '1.25rem', color: '#faf8f8ff' }}>
-          Coworking Sinergia
-        </h2>
+        <img src={logo} alt="Logo" className="app-header__logo" />
+        <div>
+          <p className="app-header__eyebrow">Coworking</p>
+          <h2 className="app-header__title">Sinergia</h2>
+        </div>
       </div>
 
-      {/* ✅ User dropdown */}
-      <div ref={menuRef} style={{ position: 'relative' }}>
+      <div ref={menuRef} className="app-header__user">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          style={{
-            border: 'none',
-            background: 'transparent',
-            cursor: 'pointer',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            color: 'white',
-          }}
+          className="app-header__user-trigger"
           aria-label="Menú de usuario"
         >
-          {/* Avatar */}
-          <div
-            style={{
-              width: 34,
-              height: 34,
-              borderRadius: '999px',
-              background: '#2563eb',
-              display: 'grid',
-              placeItems: 'center',
-              fontWeight: 800,
-              boxShadow: '0 6px 14px rgba(0,0,0,0.18)',
-            }}
-          >
-            {initials}
-          </div>
+          <div className="app-header__avatar">{initials}</div>
 
-          {/* Name + email */}
-          <div style={{ textAlign: 'left', lineHeight: 1.05 }}>
-            <div style={{ fontSize: 14, fontWeight: 800 }}>
+          <div className="app-header__user-meta">
+            <div className="app-header__user-name">
               {currentUser?.name ? `${currentUser?.name} ${currentUser?.lastName || ''}`.trim() : 'Usuario'}
             </div>
-            <div style={{ fontSize: 12, opacity: 0.9 }}>
-              {currentUser?.email || ''}
-            </div>
+            <div className="app-header__user-email">{currentUser?.email || ''}</div>
           </div>
 
-          {/* Chevron */}
-          <div style={{ fontSize: 16, marginLeft: 2, opacity: 0.95 }}>▾</div>
+          <div className="app-header__chevron">▾</div>
         </button>
 
         {open ? (
-          <div
-            style={{
-              position: 'absolute',
-              right: 0,
-              top: 'calc(100% + 10px)',
-              width: 260,
-              background: '#fff',
-              borderRadius: 12,
-              border: '1px solid rgba(0,0,0,0.10)',
-              boxShadow: '0 14px 30px rgba(0,0,0,0.20)',
-              overflow: 'hidden',
-              zIndex: 999,
-            }}
-          >
+          <div className="app-header__dropdown">
             <button
               onClick={goProfile}
-              style={{
-                width: '100%',
-                textAlign: 'left',
-                padding: '12px 14px',
-                border: 'none',
-                background: '#fff',
-                cursor: 'pointer',
-                fontWeight: 700,
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(0,0,0,0.03)')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = '#fff')}
+              className="app-header__dropdown-item"
             >
               👤&nbsp;&nbsp;Mi Perfil
             </button>
 
-            <div style={{ height: 1, background: 'rgba(0,0,0,0.08)' }} />
+            <div className="app-header__dropdown-divider" />
 
             <button
               onClick={handleLogout}
-              style={{
-                width: '100%',
-                textAlign: 'left',
-                padding: '12px 14px',
-                border: 'none',
-                background: '#fff',
-                cursor: 'pointer',
-                fontWeight: 800,
-                color: '#dc2626',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(220,38,38,0.06)')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = '#fff')}
+              className="app-header__dropdown-item app-header__dropdown-item--danger"
             >
               🚪&nbsp;&nbsp;Cerrar sesión
             </button>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -5,15 +5,9 @@ import { MdOutlineMarkEmailRead } from "react-icons/md";
 function NavItem({ to, icon, label, collapsed, active, onClick }) {
   const content = (
     <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: collapsed ? 0 : '0.6rem',
-        justifyContent: collapsed ? 'center' : 'flex-start',
-        fontSize: '0.9rem',
-      }}
+      className={`app-sidebar__item-inner ${collapsed ? 'is-collapsed' : ''}`}
     >
-      <span style={{ fontSize: '1.1rem' }}>{icon}</span>
+      <span className="app-sidebar__icon">{icon}</span>
       {!collapsed && <span>{label}</span>}
     </div>
   );
@@ -21,12 +15,14 @@ function NavItem({ to, icon, label, collapsed, active, onClick }) {
   const commonStyle = (isActive) => ({
     display: 'block',
     textDecoration: 'none',
-    color: isActive ? '#ffffff' : '#e5e7eb',
-    padding: '0.55rem 0.75rem',
-    borderRadius: '0.5rem',
-    background: isActive ? '#5686a7ff' : 'transparent',
-    marginBottom: '0.1rem',
+    color: isActive ? '#12313c' : '#f2f7f6',
+    padding: '0.75rem 0.9rem',
+    borderRadius: '1rem',
+    background: isActive ? 'linear-gradient(135deg, #9adfe5, #7fd5df)' : 'transparent',
+    marginBottom: '0.25rem',
     textAlign: collapsed ? 'center' : 'left',
+    fontWeight: isActive ? 700 : 500,
+    transition: 'all 0.2s ease',
   });
 
   if (!to) {
@@ -72,38 +68,15 @@ export default function Navbar({ collapsed, onToggle }) {
 
   return (
     <aside
-      style={{
-        width,
-        background: '#33576f',
-        color: '#e5e7eb',
-        padding: '1rem 0.75rem',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '0.75rem',
-        transition: 'width 0.2s ease',
-      }}
+      className="app-sidebar"
+      style={{ width }}
     >
-      {/* Toggle (siempre arriba) */}
       <button
         type="button"
         onClick={onToggle}
         aria-label={collapsed ? 'Expandir menú' : 'Colapsar menú'}
         title={collapsed ? 'Expandir menú' : 'Colapsar menú'}
-        style={{
-          width: '100%',
-          border: 'none',
-          background: 'transparent',
-          color: '#e5e7eb',
-          cursor: 'pointer',
-          padding: '0.55rem 0.75rem',
-          borderRadius: '0.5rem',
-          textAlign: collapsed ? 'center' : 'left',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: collapsed ? 'center' : 'flex-start',
-          fontSize: '1rem',
-          outline: 'none',
-        }}
+        className={`app-sidebar__toggle ${collapsed ? 'is-collapsed' : ''}`}
       >
         {collapsed ? '»' : '«'}
       </button>

--- a/frontend/src/pages/DashboardAdmin.jsx
+++ b/frontend/src/pages/DashboardAdmin.jsx
@@ -328,12 +328,11 @@ async function fetchCalendarReservations() {
   return (
     <Layout user={user}>
       <div className="admin-page">
-        {/* Encabezado Dashboard */}
         <div
-          className="admin-header"
-          style={{ justifyContent: 'space-between', marginBottom: '1.25rem' }}
+          className="admin-header admin-header--stacked"
         >
           <div>
+            <span className="section-kicker">Panel operativo</span>
             <h1>Panel de administrador</h1>
             <span style={{ fontSize: '0.85rem', color: '#6b7280' }}>
               Visión general de reservas y gestión del coworking
@@ -347,17 +346,8 @@ async function fetchCalendarReservations() {
           </div>
         )}
 
-        {/* Card acción rápida: agendar reserva */}
-        <div
-          className="admin-card"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            marginBottom: '1.5rem',
-          }}
-        >
-          <div>
+        <div className="admin-card admin-hero-card">
+          <div className="admin-hero-card__content">
             <h2 style={{ margin: 0, marginBottom: '0.25rem', fontSize: '1.1rem' }}>
               Agendar una reserva
             </h2>
@@ -365,7 +355,7 @@ async function fetchCalendarReservations() {
               Crea una reserva a nombre de un usuario que te contacte por teléfono, mail u otro canal.
             </p>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <div className="admin-hero-card__aside">
             <img
               src={calendarImg}
               alt="Calendario"
@@ -373,16 +363,7 @@ async function fetchCalendarReservations() {
             />
             <Link
               to="/admin/reservas/nueva"
-              style={{
-                padding: '0.6rem 1.2rem',
-                borderRadius: '10px',
-                background: '#4f46e5',
-                color: 'white',
-                fontSize: '0.9rem',
-                fontWeight: '600',
-                textDecoration: 'none',
-                whiteSpace: 'nowrap',
-              }}
+              className="button-link-primary"
             >
               Nueva reserva
             </Link>
@@ -400,7 +381,6 @@ async function fetchCalendarReservations() {
           <AdminDashboardWidgets />
         </div>
 
-        {/* Tabla de reservas (hoy en adelante) */}
         <div className="admin-card" style={{ marginBottom: '1.5rem' }}>
           <h2 style={{ marginTop: 0, marginBottom: '0.5rem', fontSize: '1.1rem' }}>
             Reservas desde hoy
@@ -451,7 +431,8 @@ async function fetchCalendarReservations() {
             </p>
           ) : (
             <>
-              <table className="admin-table">
+              <div className="admin-table-wrapper admin-table-wrapper--soft">
+              <table className="admin-table admin-table--reservations">
                 <thead>
                   <tr>
                     <th>Espacio</th>
@@ -555,6 +536,7 @@ async function fetchCalendarReservations() {
                   })}
                 </tbody>
               </table>
+              </div>
 
               {/* paginado simple */}
               <div

--- a/frontend/src/pages/DashboardUser.jsx
+++ b/frontend/src/pages/DashboardUser.jsx
@@ -31,11 +31,6 @@ function formatDateES(dateLike) {
   }).format(d);
 }
 
-function formatEUR(value) {
-  const num = Number(value || 0);
-  return new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(num);
-}
-
 function statusLabel(status) {
   switch (status) {
     case 'ACTIVE':
@@ -166,6 +161,7 @@ export default function DashboardUser() {
   const todayCount = useMemo(() => reservations.filter(isToday).length, [reservations]);
   const upcomingCount = upcoming.length;
   const upcomingTop = useMemo(() => upcoming, [upcoming]);
+  const nextReservation = upcomingTop[0] || null;
 
   function canEdit(res) {
     if (!(res?.status === 'ACTIVE' || res?.status === 'PENDING')) return false;
@@ -212,11 +208,11 @@ export default function DashboardUser() {
 
       <div className="page-container dashboard-page">
         <div className="dashboard-container">
-          {/* Top header row (mock) */}
           <div className="dashboard-user-top">
             <div className="dashboard-header">
+              <span className="section-kicker">Tu panel</span>
               <h1>Bienvenido</h1>
-              <p>Gestioná tus espacios de trabajo, reservas y próximos turnos.</p>
+              <p>Entrá y visualizá tu estado de reserva sin vueltas.</p>
               {error ? <div className="form-error">{error}</div> : null}
             </div>
 
@@ -225,7 +221,42 @@ export default function DashboardUser() {
             </button>
           </div>
 
-          {/* KPIs (mock) */}
+          {nextReservation ? (
+            <div className="hero-reservation-card">
+              <div>
+                <div className="hero-reservation-card__eyebrow">Próxima reserva</div>
+                <div className="hero-reservation-card__title">
+                  {nextReservation?.space?.name || `Espacio #${nextReservation.spaceId}`}
+                </div>
+                <div className="hero-reservation-card__meta">
+                  <span>{formatDateES(nextReservation.date)}</span>
+                  <span>{toHHMM(nextReservation.startTime)}–{toHHMM(nextReservation.endTime)}</span>
+                  <span className={`status-pill status-${nextReservation.status}`}>{statusLabel(nextReservation.status)}</span>
+                </div>
+              </div>
+              <div className="hero-reservation-card__actions">
+                <button
+                  className="pill-button-outline"
+                  type="button"
+                  onClick={() => {
+                    setDetailRes(nextReservation);
+                    setDetailOpen(true);
+                  }}
+                >
+                  Ver detalle
+                </button>
+                <button
+                  className="pill-button"
+                  type="button"
+                  onClick={() => navigate(`/user/reservar?edit=${nextReservation.id}&mode=edit`)}
+                  disabled={!canEdit(nextReservation)}
+                >
+                  Gestionar
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           <div className="dashboard-kpis">
             <div className="user-card card-accent card-accent--grey">
               <div className="kpi-title">Reservas totales</div>
@@ -246,7 +277,6 @@ export default function DashboardUser() {
             </div>
           </div>
 
-          {/* Próximas reservas (mock) */}
           <div className="user-card">
             <div className="dashboard-section-head">
               <div>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -27,7 +27,7 @@ export default function Login() {
 
         const md = res?.data?.content?.TEXT_LOGIN || '';
         if (!cancelled) setLoginTextMd(md);
-      } catch (e) {
+      } catch {
         // Silencioso: si falla, no rompe la pantalla de login
         if (!cancelled) setLoginTextMd('');
       }
@@ -64,26 +64,28 @@ export default function Login() {
   }
 
   return (
-    <div className="app-center">
-      <div className="card" style={{ textAlign: 'center' }}>
-        {/* Logo centrado */}
-        <img
-          src="/logoCoworking.png"
-          alt="Coworking Sinergia"
-          style={{ height: 64, width: 'auto', margin: '0 auto 12px', display: 'block' }}
-        />
-
-        <h1 style={{ marginTop: 0 }}>Coworking Sinergia</h1>
-
-        {/* Texto fijo (si querés, lo podés eliminar y dejar solo el Markdown) */}
-        <p style={{ marginTop: 6 }}>Inicia sesión para gestionar tus reservas.</p>
+    <div className="auth-shell">
+      <div className="auth-card">
+        <div className="auth-brand">
+          <span className="auth-brand-badge">Acceso</span>
+          <img
+            src="/logoCoworking.png"
+            alt="Coworking Sinergia"
+            className="auth-logo"
+          />
+          <h1>Coworking Sinergia</h1>
+          <p>
+            Iniciá sesión para acceder rápido a tus reservas, tu estado actual y las herramientas de gestión.
+          </p>
+        </div>
 
         {error && <div className="error">{error}</div>}
 
-        <form onSubmit={handleSubmit} style={{ textAlign: 'left' }}>
+        <form onSubmit={handleSubmit} className="auth-form">
           <div className="form-group">
             <label>Email</label>
             <input
+              className="auth-input"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -95,6 +97,7 @@ export default function Login() {
           <div className="form-group">
             <label>Contraseña</label>
             <input
+              className="auth-input"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -103,14 +106,13 @@ export default function Login() {
             />
           </div>
 
-          <button className="button" type="submit" disabled={loading}>
+          <button className="button auth-submit" type="submit" disabled={loading}>
             {loading ? 'Entrando...' : 'Entrar'}
           </button>
         </form>
-        {/* Texto dinámico desde reglas (Markdown) */}
+
         {loginTextMd ? (
-          <div style={{ marginTop: 10, marginBottom: 14, textAlign: 'center' }}>
-          <div style={{ fontSize: 14, lineHeight: 1.5, color: '#555', textAlign: 'justify', marginTop: 16 }}>
+          <div className="auth-markdown">
             <ReactMarkdown
               components={{
                 a: (props) => (
@@ -123,10 +125,10 @@ export default function Login() {
                   />
                 ),
                 ul: (props) => (
-                  <ul {...props} style={{ textAlign: 'left', margin: '8px auto', paddingLeft: 18, maxWidth: 360 }} />
+                  <ul {...props} style={{ textAlign: 'left', margin: '8px auto', paddingLeft: 18 }} />
                 ),
                 ol: (props) => (
-                  <ol {...props} style={{ textAlign: 'left', margin: '8px auto', paddingLeft: 18, maxWidth: 360 }} />
+                  <ol {...props} style={{ textAlign: 'left', margin: '8px auto', paddingLeft: 18 }} />
                 ),
                 strong: (props) => <strong {...props} style={{ fontWeight: 700 }} />,
                 p: (props) => <p {...props} style={{ margin: '6px 0' }} />,
@@ -135,10 +137,9 @@ export default function Login() {
               {loginTextMd}
             </ReactMarkdown>
           </div>
-          </div>
         ) : null}
 
-        <div style={{ marginTop: '1rem', display: 'flex', justifyContent: 'space-between' }}>
+        <div className="auth-links">
           <Link className="link" to="/register">
             Crear cuenta
           </Link>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,16 +1,46 @@
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f3f4f6;
-  color: #111827;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f4f1ea;
+  color: #16323d;
+  --brand-900: #16323d;
+  --brand-800: #244957;
+  --brand-700: #33576f;
+  --brand-500: #6cbfcb;
+  --brand-400: #8dd6de;
+  --brand-300: #bdebef;
+  --sand-50: #fbf8f2;
+  --sand-100: #f4f1ea;
+  --sand-200: #ece5d7;
+  --line-soft: rgba(22, 50, 61, 0.12);
+  --shadow-soft: 0 18px 45px rgba(22, 50, 61, 0.10);
+  --shadow-card: 0 12px 30px rgba(22, 50, 61, 0.08);
+  --radius-xl: 28px;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --card-accent-grey: #98a8ab;
+  --card-accent-blue: #7fd5df;
+  --card-accent-green: #73c9a7;
+}
 
-  /* Dashboard accents (soft tones) */
-  --card-accent-grey: #9ca3af;
-  --card-accent-blue: #60a5fa;
-  --card-accent-green: #34d399;
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  min-height: 100%;
 }
 
 body {
   margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(141, 214, 222, 0.18), transparent 28%),
+    linear-gradient(180deg, #f8f4ed 0%, #f4f1ea 100%);
+  color: var(--brand-900);
+}
+
+a {
+  color: inherit;
 }
 
 .app-center {
@@ -23,8 +53,8 @@ body {
 .card {
   background: white;
   padding: 2.5rem 2rem;
-  border-radius: 1rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
   width: 100%;
   max-width: 380px;
 }
@@ -52,29 +82,32 @@ label {
 }
 
 input {
-  border-radius: 0.5rem;
-  border: 1px solid #d1d5db;
-  padding: 0.6rem 0.8rem;
-  font-size: 0.95rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-soft);
+  padding: 0.95rem 1rem;
+  font-size: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--brand-900);
 }
 
 input:focus {
   outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 1px #4f46e5;
+  border-color: var(--brand-500);
+  box-shadow: 0 0 0 4px rgba(108, 191, 203, 0.18);
 }
 
 .button {
   border: none;
-  border-radius: 10px;
-  padding: 0.7rem 1.2rem;
+  border-radius: 999px;
+  padding: 0.9rem 1.2rem;
   font-size: 0.95rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   width: 100%;
-  background: linear-gradient(to right, #4f46e5, #6366f1);
+  background: linear-gradient(135deg, var(--brand-700), var(--brand-500));
   color: white;
   margin-top: 0.5rem;
+  box-shadow: 0 12px 24px rgba(51, 87, 111, 0.18);
 }
 
 .button:disabled {
@@ -83,9 +116,10 @@ input:focus {
 }
 
 .link {
-  color: #4f46e5;
-  font-size: 0.85rem;
+  color: var(--brand-700);
+  font-size: 0.9rem;
   text-decoration: none;
+  font-weight: 600;
 }
 
 .link:hover {
@@ -93,9 +127,13 @@ input:focus {
 }
 
 .error {
-  color: #b91c1c;
-  font-size: 0.85rem;
-  margin-bottom: 0.5rem;
+  color: #a43838;
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+  background: rgba(191, 83, 83, 0.08);
+  border: 1px solid rgba(191, 83, 83, 0.15);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1rem;
 }
 .admin-page {
   min-height: 100vh;
@@ -123,8 +161,9 @@ input:focus {
 .admin-card {
   background: white;
   padding: 1.5rem;
-  border-radius: 1rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(141, 214, 222, 0.14);
 }
 
 .admin-table {
@@ -198,13 +237,13 @@ input:focus {
 
 /* Botones estilo "pill" (como el de Reservar) */
 .pill-button {
-  height: 30px;
-  padding: 0 22px;
-  border-radius: 10px;
+  min-height: 44px;
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
   border: none;
-  background: #4f46e5;
+  background: linear-gradient(135deg, var(--brand-700), var(--brand-500));
   color: #fff;
-  font-weight: 400;
+  font-weight: 700;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -219,13 +258,13 @@ input:focus {
 }
 
 .pill-button-outline {
-  height: 30px;
-  padding: 0 18px;
-  border-radius: 10px;
-  border: 1px solid #d1d5db;
-  background: #fff;
-  color:  rgb(79, 70, 229);
-  font-weight: 300;
+  min-height: 44px;
+  padding: 0.75rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid rgba(51, 87, 111, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--brand-700);
+  font-weight: 700;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -239,9 +278,9 @@ input:focus {
 }
 
 .pill-button-green {
-  height: 30px;
-  padding: 0 22px;
-  border-radius: 10px;
+  min-height: 44px;
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
   border: none;
   background: #dcfce7;
   color: #166534;
@@ -253,9 +292,9 @@ input:focus {
   gap: 8px;
 }
 .pill-button-red {
-  height: 30px;
-  padding: 0 22px;
-  border-radius: 10px;
+  min-height: 44px;
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
   border: none;
   background: #fecaca;
   color: #b91c1c;
@@ -268,10 +307,333 @@ input:focus {
 }
 .admin-input {
   width: 100%;
-  padding: 0.4rem 0.6rem;
-  border-radius: 0.5rem;
-  border: 1px solid #d1d5db;
-  font-size: 0.9rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-soft);
+  font-size: 16px;
+}
+
+.auth-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.auth-card {
+  width: min(100%, 480px);
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(141, 214, 222, 0.18);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(10px);
+}
+
+.auth-brand {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.auth-brand-badge,
+.section-kicker {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(108, 191, 203, 0.16);
+  color: var(--brand-700);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.auth-logo {
+  height: 74px;
+  width: auto;
+  margin: 1rem auto 0.75rem;
+  display: block;
+}
+
+.auth-card h1,
+.app-header__title,
+.dashboard-header h1,
+.admin-header h1,
+.dashboard-section-title {
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+  color: var(--brand-900);
+}
+
+.auth-card p {
+  margin: 0.75rem 0 0;
+  color: rgba(22, 50, 61, 0.72);
+}
+
+.auth-form {
+  text-align: left;
+}
+
+.auth-input {
+  min-height: 52px;
+}
+
+.auth-submit {
+  margin-top: 0.75rem;
+}
+
+.auth-markdown {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line-soft);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(22, 50, 61, 0.8);
+}
+
+.auth-links {
+  margin-top: 1.1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.app-header {
+  width: 100%;
+  background: rgba(22, 50, 61, 0.92);
+  backdrop-filter: blur(14px);
+  padding: 0.9rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(141, 214, 222, 0.14);
+  box-shadow: 0 12px 30px rgba(22, 50, 61, 0.12);
+  z-index: 30;
+  position: sticky;
+  top: 0;
+}
+
+.app-header__brand,
+.app-header__user-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.app-header__menu-btn {
+  border: 1px solid rgba(255,255,255,0.18);
+  background: rgba(255,255,255,0.06);
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.app-header__menu-icon { font-size: 1.2rem; line-height: 1; color: white; font-weight: 700; }
+.app-header__logo { width: 42px; height: 42px; object-fit: contain; }
+.app-header__eyebrow { margin: 0; font-size: 0.72rem; color: rgba(255,255,255,0.72); text-transform: uppercase; letter-spacing: 0.14em; }
+.app-header__title { margin: 0; font-size: 1.35rem; color: #fff; line-height: 1; }
+.app-header__user { position: relative; }
+.app-header__user-trigger { border: none; background: transparent; cursor: pointer; color: white; }
+.app-header__avatar { width: 40px; height: 40px; border-radius: 999px; background: linear-gradient(135deg, var(--brand-400), var(--brand-500)); color: var(--brand-900); display: grid; place-items: center; font-weight: 800; box-shadow: 0 8px 20px rgba(108,191,203,0.3); }
+.app-header__user-meta { text-align: left; line-height: 1.1; }
+.app-header__user-name { font-size: 14px; font-weight: 800; }
+.app-header__user-email { font-size: 12px; opacity: 0.82; }
+.app-header__chevron { font-size: 16px; opacity: 0.9; }
+.app-header__dropdown { position: absolute; right: 0; top: calc(100% + 10px); width: 260px; background: #fff; border-radius: var(--radius-md); border: 1px solid rgba(22, 50, 61, 0.10); box-shadow: var(--shadow-soft); overflow: hidden; z-index: 999; }
+.app-header__dropdown-item { width: 100%; text-align: left; padding: 12px 14px; border: none; background: #fff; cursor: pointer; font-weight: 700; }
+.app-header__dropdown-item:hover { background: rgba(22, 50, 61, 0.04); }
+.app-header__dropdown-item--danger { color: #a43838; }
+.app-header__dropdown-item--danger:hover { background: rgba(164, 56, 56, 0.06); }
+.app-header__dropdown-divider { height: 1px; background: rgba(22, 50, 61, 0.08); }
+
+.app-sidebar {
+  background: linear-gradient(180deg, #21424f 0%, #16323d 100%);
+  color: #f2f7f6;
+  padding: 1rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: width 0.2s ease;
+  min-height: 100vh;
+  position: sticky;
+  top: 0;
+}
+
+.app-sidebar__toggle {
+  width: 100%;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
+  color: #e5f6f8;
+  cursor: pointer;
+  padding: 0.75rem 0.9rem;
+  border-radius: 1rem;
+  text-align: left;
+  font-size: 1rem;
+}
+
+.app-sidebar__toggle.is-collapsed { text-align: center; }
+.app-sidebar__item-inner { display: flex; align-items: center; gap: 0.65rem; justify-content: flex-start; font-size: 0.95rem; }
+.app-sidebar__item-inner.is-collapsed { justify-content: center; }
+.app-sidebar__icon { font-size: 1.1rem; display: inline-flex; }
+
+.admin-header--stacked {
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.admin-hero-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+  background: linear-gradient(135deg, rgba(255,255,255,0.96), rgba(189, 235, 239, 0.28));
+}
+
+.admin-hero-card__content { flex: 1; }
+.admin-hero-card__aside { display: flex; align-items: center; gap: 1rem; }
+
+.button-link-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.35rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--brand-700), var(--brand-500));
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+  box-shadow: 0 12px 24px rgba(51, 87, 111, 0.18);
+}
+
+.hero-reservation-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.4rem 1.5rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(22, 50, 61, 0.96), rgba(51, 87, 111, 0.94));
+  color: #fff;
+  box-shadow: var(--shadow-soft);
+  margin-bottom: 1.25rem;
+}
+
+.hero-reservation-card__eyebrow {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.78;
+  margin-bottom: 0.45rem;
+}
+
+.hero-reservation-card__title {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.hero-reservation-card__meta {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 0.65rem;
+  color: rgba(255,255,255,0.84);
+}
+
+.hero-reservation-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.admin-table-wrapper--soft {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  border-radius: var(--radius-md);
+}
+
+.admin-table--reservations {
+  min-width: 920px;
+}
+
+.dashboard-container {
+  max-width: 1240px;
+}
+
+@media (max-width: 900px) {
+  .hero-reservation-card,
+  .admin-hero-card,
+  .dashboard-user-top,
+  .app-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app-header__user-trigger,
+  .app-header__brand {
+    justify-content: space-between;
+  }
+
+  .app-header__user-meta {
+    flex: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-shell,
+  .admin-page {
+    padding: 1rem;
+  }
+
+  .auth-card,
+  .admin-card,
+  .card,
+  .hero-reservation-card {
+    border-radius: var(--radius-md);
+  }
+
+  .auth-links,
+  .hero-reservation-card__actions,
+  .upcoming-actions--inline,
+  .admin-hero-card__aside {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button,
+  .pill-button,
+  .pill-button-outline,
+  .pill-button-red,
+  .pill-button-green,
+  .button-link-primary {
+    width: 100%;
+  }
+
+  .app-header {
+    padding: 0.9rem 1rem;
+  }
+
+  .app-header__user-email {
+    display: none;
+  }
+
+  .dashboard-section-head {
+    gap: 0.85rem;
+  }
 }
 
 /* ---------- PROFILE LAYOUT ---------- */


### PR DESCRIPTION
### Motivation
- Unificar la UX/UI de la App de Logueo (User & Admin) y los dashboards con la estética de la landing para dar coherencia de marca. 
- Mantener intacta la lógica de autenticación y estados, limitando cambios a la capa de presentación (JSX/CSS). 
- Mejorar la experiencia móvil: inputs >=16px, botones full-width en pantallas pequeñas y scroll horizontal suave en tablas densas. 

### Description
- Reorganicé la pantalla de login y su CSS creando una estructura `auth-shell`/`auth-card`, clases `auth-input` y `auth-submit`, y una zona de marca con logo y badge para reforzar identidad; todo sin tocar la lógica de `handleSubmit`. 
- Rediseñé el `Header` y `Navbar` para usar clases reutilizables (`app-header`, `app-sidebar`, avatar refinado, dropdown estilizado y estados activos del menú más visibles). 
- Mejoré las vistas de dashboard: en `DashboardUser` destaque la próxima reserva con un `hero-reservation-card` y accesos rápidos; en `DashboardAdmin` creé un `admin-hero-card` y envolví la tabla en `admin-table-wrapper--soft` para scroll horizontal suave en mobile. 
- Centralicé la paleta, radios y sombras en `styles.css` (variables CSS: `--brand-*`, `--radius-*`, `--shadow-*`), forcé `font-size:16px` en inputs y amplié botones a full-width en resoluciones pequeñas; eliminé únicamente cambios no funcionales (presentación). 

### Testing
- Ejecuté `npm install` en `frontend` y la instalación completó correctamente. ✅
- Ejecuté `npm run build` en `frontend` y la build de Vite finalizó correctamente (bundle generado). ✅
- Ejecuté `npm run lint` en `frontend` y reportó errores preexistentes en varios archivos no relacionados con este refactor, por lo que el lint falló (issues fuera del alcance de este PR). ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04227b3f0832f95efd62e01c057b7)